### PR TITLE
This whole app seems to be unneeded

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,26 @@
 > a GitHub App built with [probot](https://github.com/probot/probot) that
 > makes it easy to manage chained pull requests.
 
+## Note: You probably don't need this
+
+GitHub will automatically change the base of pull requests that currently
+have their head set to the branch being deleted if the deleting is done
+automatically on merge or via the button on the pull request.
+
+So if you merge a pull request, and then you click the "Delete branch" button:
+
+![Delete branch button](delete-branch.png)
+
+Then you'll see this on all the dependent pull requests:
+
+![Base automatically changed activity](base-changed.png)
+
+And this also works if you have GitHub delete branches automatically on merge:
+
+![Automatically delete head branches checkbox in settings](auto-delete-on-merge.png)
+
+So you probably don't need this. If you think you actually do need this, open up an issue and tell me. I'll probably delete this app in a while if you don't.
+
 ## Usage
 
 Chain helps manage the drudgery of dealing with chained pull requests.


### PR DESCRIPTION
It may even have been that it was already obsolete when it was created, I just didn't know it. Either way, it seems that GitHub may be even smarter than I am ;-).

When GitHub deletes a branch because a pull request is merged, either via the automatic deletion of branches or by clicking the "delete branch" button on the pull request, it will automatically change the base of pull requests that depend on it.

One thing that is worth noting that deleting a branch via git CLI does *not* trigger this behavior. The behavior is only triggered when GitHub knows that the deleting is happening from the pull request, either by pressing that "Delete branch" button, or by having GitHub automatically delete branches when the PR get merged.